### PR TITLE
Fix demo video playback with inline HTML5 embeds

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -31,41 +31,41 @@
   <tr>
     <td width="50%">
       <h4>📋 Demo 1: Discovery (~15s)</h4>
-      <a href="demo-1-discovery.mp4">
-        <img src="demo-1-discovery.png" alt="Demo 1: Discovery" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-1-discovery.png">
+        <source src="demo-1-discovery.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Tools:</strong> <code>acp_list_projects</code>, <code>acp_list_sessions</code>, <code>acp_get_events</code></p>
       <p>Daily project navigation and session monitoring.</p>
-      <p><a href="demo-1-discovery.mp4">▶️ Watch Demo 1</a></p>
     </td>
     <td width="50%">
       <h4>🔄 Demo 2: Lifecycle (~20s)</h4>
-      <a href="demo-2-lifecycle.mp4">
-        <img src="demo-2-lifecycle.png" alt="Demo 2: Lifecycle" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-2-lifecycle.png">
+        <source src="demo-2-lifecycle.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Tools:</strong> <code>acp_create_session</code>, <code>acp_get_session</code>, <code>acp_stop_session</code></p>
       <p>Create, check status, and stop sessions.</p>
-      <p><a href="demo-2-lifecycle.mp4">▶️ Watch Demo 2</a></p>
     </td>
   </tr>
   <tr>
     <td width="50%">
       <h4>🔍 Demo 3: Investigation (~18s)</h4>
-      <a href="demo-3-investigation.mp4">
-        <img src="demo-3-investigation.png" alt="Demo 3: Investigation" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-3-investigation.png">
+        <source src="demo-3-investigation.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Tools:</strong> <code>acp_list_sessions</code>, <code>acp_get_events</code></p>
       <p>Monitor active sessions and retrieve event history.</p>
-      <p><a href="demo-3-investigation.mp4">▶️ Watch Demo 3</a></p>
     </td>
     <td width="50%">
       <h4>⚠️ Demo 4: Delete Workaround (~12s)</h4>
-      <a href="demo-4-missing-delete.mp4">
-        <img src="demo-4-missing-delete.png" alt="Demo 4: Delete Workaround" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-4-missing-delete.png">
+        <source src="demo-4-missing-delete.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Tools:</strong> Bash fallback (<code>oc delete</code>)</p>
       <p>Shows missing delete tool, bash fallback to <code>oc delete</code>.</p>
-      <p><a href="demo-4-missing-delete.mp4">▶️ Watch Demo 4</a></p>
     </td>
   </tr>
 </table>
@@ -76,48 +76,48 @@
   <tr>
     <td width="50%">
       <h4>⚡ Demo 5: Session Templates (~25s)</h4>
-      <a href="demo-5-session-template.mp4">
-        <img src="demo-5-session-template.png" alt="Demo 5: Session Templates" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-5-session-template.png">
+        <source src="demo-5-session-template.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Session:</strong> 391-message | "How can I connect OpenCode CLI to Ambient Code Platform?"</p>
       <p><strong>Tools:</strong> <code>acp_list_workflows</code>, <code>acp_create_session_from_template</code>, <code>acp_get_session</code></p>
       <p>Lists templates (triage, bugfix, feature, integration) → Creates session with pre-loaded repos, K8s context, docs, and workflow phases.</p>
       <p><strong>Impact:</strong> 60% time reduction (~45min saved) on multi-repo integration setup.</p>
-      <p><a href="demo-5-session-template.mp4">▶️ Watch Demo 5</a></p>
     </td>
     <td width="50%">
       <h4>⭐ Demo 6: Crash Recovery + Bulk Operations (~45s)</h4>
-      <a href="demo-6-crash-recovery.mp4">
-        <img src="demo-6-crash-recovery.png" alt="Demo 6: Crash Recovery" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-6-crash-recovery.png">
+        <source src="demo-6-crash-recovery.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Session:</strong> 295-message | "our last session crashed... working on agentready repo"</p>
       <p><strong>Tools:</strong> <code>acp_list_sessions(status="failed")</code>, <code>acp_get_session_transcript</code>, <code>acp_clone_session</code>, <code>acp_bulk_create_sessions</code>, <code>acp_get_session_metrics</code>, <code>acp_bulk_stop_sessions</code></p>
       <p>Session crashed after analyzing 6/13 features → List failed → Get transcript (295 msgs) → Clone → Bulk create 7 parallel sessions → Monitor metrics (73% complete) → Bulk stop.</p>
       <p><strong>Impact:</strong> 72% time reduction (3h → 50min). Shows real crash recovery, parallelization (7 concurrent sessions), and multi-agent orchestration.</p>
-      <p><a href="demo-6-crash-recovery.mp4">▶️ Watch Demo 6</a></p>
     </td>
   </tr>
   <tr>
     <td width="50%">
       <h4>📊 Demo 7: Metrics & Export (~35s)</h4>
-      <a href="demo-7-metrics-export.mp4">
-        <img src="demo-7-metrics-export.png" alt="Demo 7: Metrics & Export" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-7-metrics-export.png">
+        <source src="demo-7-metrics-export.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Session:</strong> 5,262-message (6h 23m) | "Search for code patterns... testing LLM-generated code"</p>
       <p><strong>Tools:</strong> <code>acp_get_session_metrics</code>, <code>acp_update_session</code>, <code>acp_get_session_logs</code>, <code>acp_export_session</code></p>
       <p>Get metrics (5,262 msgs, 1,847 tool calls, 412 files, $127.50 token cost) → Extend timeout (6h→12h) → Get logs → Export for archival.</p>
       <p><strong>Impact:</strong> Observability for monster sessions, cost tracking, team sharing, compliance trails.</p>
-      <p><a href="demo-7-metrics-export.mp4">▶️ Watch Demo 7</a></p>
     </td>
     <td width="50%">
       <h4>🔀 Demo 8: Multi-Provider Comparison (~30s)</h4>
-      <a href="demo-8-bulk-comparison.mp4">
-        <img src="demo-8-bulk-comparison.png" alt="Demo 8: Multi-Provider Comparison" width="100%">
-      </a>
+      <video width="100%" controls poster="demo-8-bulk-comparison.png">
+        <source src="demo-8-bulk-comparison.mp4" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
       <p><strong>Session:</strong> Bulk operations across AI providers</p>
       <p><strong>Tools:</strong> <code>acp_bulk_create_sessions</code>, <code>acp_bulk_send_message</code>, <code>acp_bulk_get_session_metrics</code>, <code>acp_bulk_stop_sessions</code></p>
       <p>Query Google Gemini, Anthropic Claude, OpenAI GPT-4 in parallel for comparison and A/B testing.</p>
-      <p><a href="demo-8-bulk-comparison.mp4">▶️ Watch Demo 8</a></p>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
Replace clickable image links with HTML5 `<video>` tags to enable inline video playback on GitHub.

## Problem
Clicking on demo thumbnails redirected to raw .mp4 download page instead of playing videos inline.

## Solution
Use HTML5 `<video>` tags with:
- `controls` attribute for play/pause controls
- `poster` attribute to show thumbnail before play
- Embedded `.mp4` source files

## Changes
- Updated all 8 demo videos to use `<video>` tags
- Removed redundant "▶️ Watch Demo" links (controls provide play button)
- Videos now play directly in GitHub README

## Testing
View updated demos at: https://github.com/ambient-code/mcp/blob/fix/demo-video-playback/demos/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)