### PR TITLE
feat: Add automatic semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,29 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
-  build-and-publish:
+  release:
     runs-on: ubuntu-latest
-    environment: pypi  # Use production PyPI environment
+    concurrency: release
     permissions:
-      id-token: write  # Required for trusted publishing to PyPI
-      contents: read
+      id-token: write
+      contents: write
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcp-acp/
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,19 +36,24 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
-      - name: Build wheel and sdist
+      - name: Python Semantic Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v9.15.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build package
+        if: steps.release.outputs.released == 'true'
         run: uvx --from build pyproject-build --installer uv
 
-      - name: Prune uv cache for CI
-        run: uv cache prune --ci
-
-      - name: Upload release artifacts to GitHub
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-packages
-          path: dist/
-
       - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+      - name: Upload artifacts to GitHub Release
+        if: steps.release.outputs.released == 'true'
+        uses: python-semantic-release/publish-action@v9.15.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,16 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html",
 ]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+commit_message = "chore(release): {version}"
+build_command = "uvx --from build pyproject-build --installer uv"
+
+[tool.semantic_release.remote]
+type = "github"
+token = { env = "GH_TOKEN" }
+
+[tool.semantic_release.publish]
+upload_to_vcs_release = true


### PR DESCRIPTION
## Summary
- Add python-semantic-release for automatic version management
- Workflow now auto-bumps version and releases on push to main
- Uses conventional commits to determine version bump type

## How it works
| Commit prefix | Version bump | Example |
|--------------|--------------|---------|
| `fix:` | Patch | 0.1.0 → 0.1.1 |
| `feat:` | Minor | 0.1.0 → 0.2.0 |
| `BREAKING CHANGE:` | Major | 0.1.0 → 1.0.0 |

## Release flow
1. Push/merge to main triggers workflow
2. Semantic-release analyzes commits since last release
3. If releasable commits found:
   - Bumps version in `pyproject.toml`
   - Commits and tags the release
   - Builds wheel/sdist
   - Publishes to PyPI (trusted publishing)
   - Creates GitHub Release with artifacts

## Files changed
- `pyproject.toml` - Added `[tool.semantic_release]` config
- `.github/workflows/release.yml` - Updated to use semantic-release action

## Test Plan
- [x] All 45 tests pass
- [x] Linting passes
- [ ] Merge and verify first auto-release works