### PR TITLE
fix: Use standard python build in semantic-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ addopts = [
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 commit_message = "chore(release): {version}"
-build_command = "uvx --from build pyproject-build --installer uv"
+build_command = "pip install build && python -m build"
 
 [tool.semantic_release.remote]
 type = "github"


### PR DESCRIPTION
The semantic-release action runs in its own container where `uvx` is not available.

Changed `build_command` from:
```
uvx --from build pyproject-build --installer uv
```
to:
```
pip install build && python -m build
```