### PR TITLE
fix: Use correct AgenticSession API version

### DIFF
--- a/src/mcp_acp/client.py
+++ b/src/mcp_acp/client.py
@@ -1184,7 +1184,7 @@ class ACPClient:
 
             # Create session manifest
             manifest = {
-                "apiVersion": "agenticplatform.io/v1",
+                "apiVersion": "vteam.ambient-code/v1alpha1",
                 "kind": "AgenticSession",
                 "metadata": {
                     "generateName": f"{source_session}-clone-",
@@ -1649,7 +1649,7 @@ class ACPClient:
         try:
             # Create session manifest
             manifest = {
-                "apiVersion": "agenticplatform.io/v1",
+                "apiVersion": "vteam.ambient-code/v1alpha1",
                 "kind": "AgenticSession",
                 "metadata": {
                     "generateName": f"{template}-",


### PR DESCRIPTION
## Summary
- Replace incorrect hardcoded apiVersion `agenticplatform.io/v1` with `vteam.ambient-code/v1alpha1` in `clone_session` and `create_session_from_template` manifests

Fixes #19

## Test plan
- [x] All 45 existing tests pass
- [ ] Verify `clone_session` creates manifests with correct apiVersion on vteam-uat
- [ ] Verify `create_session_from_template` creates manifests with correct apiVersion on vteam-uat

🤖 Generated with [Claude Code](https://claude.com/claude-code)