### PR TITLE
fix(ci): use --allow-existing flag for uv venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             venv-${{ runner.os }}-
 
       - name: Create virtual environment
-        run: uv venv
+        run: uv venv --allow-existing
 
       - name: Install dependencies
         run: uv pip install -e ".[dev]"


### PR DESCRIPTION
## Summary
- Fix CI failure when venv cache is restored by using `--allow-existing` flag

When the virtual environment cache is restored from a previous run, the `.venv` directory already exists. This causes `uv venv` to fail with an error. The `--allow-existing` flag allows uv to reuse or recreate the venv as needed.

## Test plan
- [ ] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)